### PR TITLE
base_model.py:10:1: E302 expected 2 blank lines, found 1: Pycodestyle

### DIFF
--- a/models/base_model.py
+++ b/models/base_model.py
@@ -7,6 +7,7 @@ import uuid
 from datetime import datetime
 import models
 
+
 class BaseModel():
     '''
     BaseModel definition


### PR DESCRIPTION
The pycdestyle - `pep8` was used.